### PR TITLE
Use `main` branch instead of `master`

### DIFF
--- a/app/mainapp.go
+++ b/app/mainapp.go
@@ -34,7 +34,7 @@ func MainApp(version string) *cli.App {
 		},
 		cli.StringFlag{
 			Name:  "source, s",
-			Value: "https://github.com/tldr-pages/tldr/archive/master.zip",
+			Value: "https://github.com/tldr-pages/tldr/archive/main.zip",
 			Usage: "Source URL pointing to the zip file",
 			// EnvVar: "LEGACY_COMPAT_LANG,APP_LANG,LANG",
 		},


### PR DESCRIPTION
[About 1.5 years ago](https://github.com/tldr-pages/tldr/discussions/5868), we deprecated the `master` branch in favor of the `main` branch. We intend to remove it [soon, likely by May 1st 2023](https://github.com/tldr-pages/tldr/issues/9628).